### PR TITLE
Support for lumen 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "illuminate/support": "~5.5",
         "predis/predis": "^1.1",
         "ramsey/uuid": "^3.5",
-        "symfony/debug": "~3.3"
+        "symfony/debug": "~4.0",
+
     },
     "require-dev": {
         "mockery/mockery": "~1.0",


### PR DESCRIPTION
Lumen 5.6 components use symfony/debug:~4.0
This changes will allow use this package on Lumen 5.6